### PR TITLE
Add multiple events in a single `add` call.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,22 @@
 //TODO: use .off when .on is used to register
 
-var required = function (eventsArrayIn, callback, scopeIn, multiple) {
+var flatten = function () {
+		'use strict';
+		var args = [].slice.call(arguments),
+			flat = [],
+			fltn = function (arry) {
+				return arry.reduce(function (flat, item) {
+					if (Array.isArray(item)) {
+						flat.concat(fltn(item));
+					} else {
+						flat.push(item);
+					}
+					return flat;
+				}, flat);
+			};
+		return [].concat(fltn(args));
+	}
+	, required = function (eventsArrayIn, callback, scopeIn, multiple) {
 		'use strict';
 
 		var that = this
@@ -37,7 +53,7 @@ var required = function (eventsArrayIn, callback, scopeIn, multiple) {
 			, stateCheck = function () {
 				//the state check function... it checks to see if all the events have triggered
 				var ready = true;
-				
+
 				eventArray.forEach(function (event) {
 					ready = ready && (typeof eventData[eventArray.indexOf(event)] !== 'undefined');
 				});
@@ -50,7 +66,7 @@ var required = function (eventsArrayIn, callback, scopeIn, multiple) {
 					//	mark called true so we don't call the callback mulitple times
 					if(!multiple){
 						called = true;
-						
+
 						if(isOn){ //if we used .on to bind then unbind the listeners we created
 							clear();
 						}
@@ -58,15 +74,19 @@ var required = function (eventsArrayIn, callback, scopeIn, multiple) {
 				}
 			}
 
-			, addState = function (event) {
-				var index = eventArray.indexOf(event);
-				if(index === -1){
-					eventArray.push(event);
-					index = eventArray.length - 1;
-				}
+			, addState = function () {
+				var events = flatten([].slice.call(arguments));
 
-				updateData[index] = updateState(event);
-				listen.apply(that, [event, updateData[index]]);
+				events.forEach(function (event) {
+					var index = eventArray.indexOf(event);
+					if(index === -1){
+						eventArray.push(event);
+						index = eventArray.length - 1;
+					}
+
+					updateData[index] = updateState(event);
+					listen.apply(that, [event, updateData[index]]);
+				});
 			};
 
 		if(multiple){ //if it is supposed to trigger muliple times then we need to use .on not .once or .one

--- a/app_test.js
+++ b/app_test.js
@@ -17,7 +17,7 @@ describe('The Main Tests for event-state', function () {
 
 	describe('Events should trigger the state machine', function () {
 		it('callback should receive an array', function (done) {
-			
+
 			emitter.required(['test-event', 'test-event-2'], function (dataArray) {
 				assert.isArray(dataArray);
 				assert.strictEqual(dataArray.length, 2);
@@ -29,7 +29,7 @@ describe('The Main Tests for event-state', function () {
 		});
 
 		it('callback array should be ordered in the same order as events', function (done) {
-			
+
 			emitter.required(['test-event', 'test-event-2'], function (dataArray) {
 				assert.isArray(dataArray);
 				assert.strictEqual('test-event', dataArray[0]);
@@ -42,12 +42,12 @@ describe('The Main Tests for event-state', function () {
 		});
 
 		it('multiple groups of events should trigger nicely and independently', function (done) {
-			
+
 			emitter.required(['test-event', 'test-event-2'], function (dataArray) {
 				assert.isArray(dataArray);
 				assert.strictEqual('test-event', dataArray[0]);
 				assert.strictEqual('test-event-2', dataArray[1]);
-				
+
 				emitter.emit('test-event-3', 'test-event-3');
 			});
 
@@ -122,17 +122,19 @@ describe('The Main Tests for event-state', function () {
 			assert.isFunction(requiredEvent.add);
 		});
 
-		it('should add additional functions when add is called', function (done) {
+		it('should add additional functions when add is called with one or more events', function (done) {
 			var requiredEvent = emitter.required(['test-event-4', 'test-event-5'], function (arr) {
-					assert.strictEqual(3, arr.length);
+					assert.strictEqual(4, arr.length);
 					done();
 				});
 
-			//cancel the event		
+			//cancel the event
 			emitter.emit('test-event-4', 'test-event');
 			requiredEvent.add('test-event-6');
 			emitter.emit('test-event-5', 'test-event-2');
+			requiredEvent.add('test-event-6', 'test-event-7');
 			emitter.emit('test-event-6', 'test-event-6');
+			emitter.emit('test-event-7', 'test-event-7');
 		});
 	});
 });

--- a/app_test.js
+++ b/app_test.js
@@ -124,7 +124,7 @@ describe('The Main Tests for event-state', function () {
 
 		it('should add additional functions when add is called with one or more events', function (done) {
 			var requiredEvent = emitter.required(['test-event-4', 'test-event-5'], function (arr) {
-					assert.strictEqual(4, arr.length);
+					assert.strictEqual(6, arr.length);
 					done();
 				});
 
@@ -133,8 +133,11 @@ describe('The Main Tests for event-state', function () {
 			requiredEvent.add('test-event-6');
 			emitter.emit('test-event-5', 'test-event-2');
 			requiredEvent.add('test-event-6', 'test-event-7');
+			requiredEvent.add(['test-event-8', 'test-event-9']);
 			emitter.emit('test-event-6', 'test-event-6');
 			emitter.emit('test-event-7', 'test-event-7');
+			emitter.emit('test-event-8', 'test-event-8');
+			emitter.emit('test-event-9', 'test-event-9');
 		});
 	});
 });

--- a/readme.md
+++ b/readme.md
@@ -1,33 +1,50 @@
 # event-state
 
-One of the key elements of any 
+A state machine for events.
 
 ## API
 
 ```
-var state = required(['event-one', 'event-two'], function (dataArray) {
-	//this function will be executed when all of the 
+var Emitter = require('events').EventEmitter, //Any event emitter will do.
+    emitter = new Emitter(),
+	state;
+
+// Event State extends your chosen event emitter.
+emitter.required = require('event-state');
+
+// `required` returns a state object with `add` and `clear` methods.
+state = emitter.required(['event-one', 'event-two'], function (dataArray) {
+	//this function will be executed when all of the
 	//	required events are triggered.
 }, scope);
 
+// The `add` method will dynamically add events to your event state machine.
+// Multiple events can be added either as an arguments list or an array of events.
 state.add('event-three');
+state.add('event-three', 'event-four');
+state.add(['event-five', 'event-six']);
 
+// `cancel` will remove all events from your state machine.
 state.cancel();
 ```
 
-Very simple and concise. Takes an array of events, and when all the events have been triggered it executes the callback passing it an array containing the data recieved by each event. 
+Very simple and concise. Collects a list of events, and when all the events have been triggered it executes the callback passing it an array containing the data received by each event in the order in which they were added.
 
-`dataArray` is in the order in which the events are declared in the required events array.
+`dataArray` is in the order in which the events are declared in the required events array and the order in which they were added via the `add` method.
 
 `scope` is the scope that will be applied to the callback function.
 
 `required` needs to be attached to an event emitter that has an `on`, `one` or `once` function that listens to events. It uses one of them (once > one > on) to do it's listening. `on` is less then ideal and most likely will cause a memory leak of some sort.
 
-`required` returns a funciton that cancels it.
+`required` returns an object with `add` and `cancel` methods.
+
+The `add` method dynamically adds events to the state machine. The required callback will only fire once the event-state machine has "heard" all events registered with it.
+
+The `cancel` method will immediately clear the event-state machine of all events.
 
 ### Returns
 `state` above is an object that contains a `cancel` and `add` function respectively.
 
-`state.add(event-name-in)` adds that event to your required state. This is handy for lots of stuff... ok like one thing: building file structure into an object.
+`state.add(event-name-in)` adds that event or events to your required state. This is handy for lots of stuff... ok like one thing: building file structure into an object.
 
 `state.cancel()` let's you cancel the entire thing. That way if you are waiting on event-a, event-b and event-x but want to bail on the operation if event-x and event-y are triggered then you just call state.cancel() and are done with it.


### PR DESCRIPTION
This pull request adds the ability to add more than one event to the event-state machine in with the `add` method. It also updates the tests and docs appropriately.
